### PR TITLE
Adyen's CAL endpoints fix

### DIFF
--- a/lib/adyen/client.rb
+++ b/lib/adyen/client.rb
@@ -40,17 +40,21 @@ module Adyen
         case service
         when "Checkout"
           url = "https://checkout-#{@env}.adyen.com/checkout"
+          supports_live_prefix = true
         when "CheckoutUtility"
           url = "https://checkout-#{@env}.adyen.com"
+          supports_live_prefix = true
         when "Account", "Fund", "Notification"
           url = "https://cal-#{@env}.adyen.com/cal/services"
+          supports_live_prefix = false
         when "Recurring", "Payment", "Payout"
           url = "https://pal-#{@env}.adyen.com/pal/servlet"
+          supports_live_prefix = true
         else
           raise ArgumentError, "Invalid service specified"
         end
 
-        if @env == :live
+        if @env == :live && supports_live_prefix
           url.insert(8, "#{@live_url_prefix}-")
           url["adyen.com"] = "adyenpayments.com"
         end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -37,4 +37,32 @@ RSpec.describe Adyen do
       to raise_error(Adyen::AuthenticationError)
     @shared_values[:client].api_key = "api_key"
   end
+
+  it "generates the correct service URL base for CAL TEST" do
+    client = Adyen::Client.new(env: :test)
+    client.live_url_prefix = "abcdef1234567890-TestCompany"
+    expect(client.service_url_base("Account")).
+      to eq("https://cal-test.adyen.com/cal/services")
+  end
+
+  it "generates the correct service URL base for CAL LIVE" do
+    client = Adyen::Client.new(env: :live)
+    client.live_url_prefix = "abcdef1234567890-TestCompany"
+    expect(client.service_url_base("Account")).
+      to eq("https://cal-live.adyen.com/cal/services")
+  end
+
+  it "generates the correct service URL base for PAL TEST" do
+    client = Adyen::Client.new(env: :test)
+    client.live_url_prefix = "abcdef1234567890-TestCompany"
+    expect(client.service_url_base("Payment")).
+      to eq("https://pal-test.adyen.com/pal/servlet")
+  end
+
+  it "generates the correct service URL base for PAL LIVE" do
+    client = Adyen::Client.new(env: :live)
+    client.live_url_prefix = "abcdef1234567890-TestCompany"
+    expect(client.service_url_base("Payment")).
+      to eq("https://abcdef1234567890-TestCompany-pal-live.adyenpayments.com/pal/servlet")
+  end
 end


### PR DESCRIPTION
Adyen's CAL endpoints (for the MarketPay Account/Fund/Notification endpoints) do not support the live URL prefix yet.

This commit excludes the CAL services from going through the prefix logic, and adds tests to guard this.